### PR TITLE
Add country list connector example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea
 target
 *.iml
+npm-debug.log

--- a/node/countries/package.json
+++ b/node/countries/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "countries",
+  "version": "1.0.0",
+  "description": "A Signavio Workflow connector that provides a list of countries",
+  "main": "server.js",
+  "scripts": {
+    "start": "node src/server"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/effektif/connector-examples.git"
+  },
+  "author": "Peter Hilton",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/effektif/connector-examples/issues"
+  },
+  "homepage": "https://github.com/effektif/connector-examples#readme",
+  "dependencies": {
+    "cldr-core": ">=26",
+    "cldr-localenames-modern": ">=26",
+    "express": "^4.14.0",
+    "lodash": "^4.14.1"
+  }
+}

--- a/node/countries/src/descriptor.js
+++ b/node/countries/src/descriptor.js
@@ -1,0 +1,97 @@
+module.exports = {
+  key: "countries",
+  name: "Countries",
+  description: "List of country names, in different languages",
+  typeDescriptors: [
+    {
+      "key" : "de",
+      "name" : "Land",
+      "fields" : [
+        {
+          "key" : "code",
+          "name" : "Ländercode",
+          "type" : {
+            "name" : "text"
+          }
+        },
+        {
+          "key" : "name",
+          "name" : "Name",
+          "type" : {
+            "name" : "text"
+          }
+        }
+      ],
+      "optionsAvailable" : true,
+      "fetchOneAvailable" : false
+    },
+    {
+      "key" : "en",
+      "name" : "Country",
+      "fields" : [
+        {
+          "key" : "code",
+          "name" : "Code",
+          "type" : {
+            "name" : "text"
+          }
+        },
+        {
+          "key" : "name",
+          "name" : "Name",
+          "type" : {
+            "name" : "text"
+          }
+        }
+      ],
+      "optionsAvailable" : true,
+      "fetchOneAvailable" : false
+    },
+    {
+      "key" : "es",
+      "name" : "País",
+      "fields" : [
+        {
+          "key" : "code",
+          "name" : "Código",
+          "type" : {
+            "name" : "text"
+          }
+        },
+        {
+          "key" : "name",
+          "name" : "Nombre",
+          "type" : {
+            "name" : "text"
+          }
+        }
+      ],
+      "optionsAvailable" : true,
+      "fetchOneAvailable" : false
+    },
+    {
+      "key" : "fr",
+      "name" : "Pays",
+      "fields" : [
+        {
+          "key" : "code",
+          "name" : "Code",
+          "type" : {
+            "name" : "text"
+          }
+        },
+        {
+          "key" : "name",
+          "name" : "Nom",
+          "type" : {
+            "name" : "text"
+          }
+        }
+      ],
+      "optionsAvailable" : true,
+      "fetchOneAvailable" : false
+    }
+  ],
+  version: 1,
+  protocolVersion: 1
+}

--- a/node/countries/src/server.js
+++ b/node/countries/src/server.js
@@ -1,0 +1,50 @@
+const _ = require("lodash");
+const express = require("express");
+const app = express();
+
+const descriptor = require("./descriptor");
+const de = require("cldr-localenames-modern/main/de/territories");
+const en = require("cldr-localenames-modern/main/en/territories");
+const es = require("cldr-localenames-modern/main/es/territories");
+const fr = require("cldr-localenames-modern/main/fr/territories");
+const data = _.merge({}, de, en, es, fr);
+
+// Serves the JSON type descriptor.
+app.get("/", function(req, res) {
+    res.json(descriptor);
+});
+
+// Serves CLDR countries, with ISO 3166-1 alpha-2 country codes and country names in the given language.
+app.get("/:language/options", function(request, response) {
+  const language = request.params.language;
+
+  if(!data.main[language]) {
+      return response.status(404).send();
+  }
+
+  const territories = data.main[language].localeDisplayNames.territories;
+
+  const countryCodes = _.filter(_.keys(territories), function(code) {
+    // Exclude continents, alternative names and ‘Unknown region’ (ZZ).
+    return code.length == 2 && code != "ZZ";
+  });
+
+  const options = _.map(countryCodes, function(code) {
+      return {
+        code: code,
+        name: territories[code]
+      };
+  });
+
+  const query = request.query.filter || "";
+
+  const filteredOptions = _.filter(options, function(option) {
+      return _.includes(option.name.toLowerCase(), query.toLowerCase());
+  });
+
+  response.json(filteredOptions);
+});
+
+app.listen(5000, function() {
+    console.log("Connector listening on port 5000.");
+});


### PR DESCRIPTION
Adds a connector example, based on the existing `data-source` example, that uses https://github.com/unicode-cldr/cldr-json to provide a list of localised country names.