### PR TITLE
Updated spark dependency to fix vulnerability

### DIFF
--- a/java/data-source-sql/pom.xml
+++ b/java/data-source-sql/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.sparkjava</groupId>
       <artifactId>spark-core</artifactId>
-      <version>2.5</version>
+      <version>2.7.2</version>
     </dependency>
 
     <dependency>

--- a/java/data-source/pom.xml
+++ b/java/data-source/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.sparkjava</groupId>
       <artifactId>spark-core</artifactId>
-      <version>2.7.1</version>
+      <version>2.7.2</version>
     </dependency>
 
     <dependency>

--- a/java/database-update/pom.xml
+++ b/java/database-update/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.sparkjava</groupId>
       <artifactId>spark-core</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.2</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>


### PR DESCRIPTION
In order to fix the GitHub security warnings, I updated the `spark-core` dependency to version `2.7.2`.